### PR TITLE
Fast error computation

### DIFF
--- a/src/QuadraticOutputSystems.jl
+++ b/src/QuadraticOutputSystems.jl
@@ -3,6 +3,8 @@ module QuadraticOutputSystems
 using LinearAlgebra
 using MatrixEquations
 
+sym(A) = 0.5 * (A + A')
+
 """
     h2norm(A, B, M)
 
@@ -32,10 +34,10 @@ function h2error(
     A2,
     B2,
     M2;
-    BQ1B=B1' * qo_observability_gramian(A1, B1, M1) * B1,
-    X=sylvc(A1, A2', -B1 * B2'),
+    BQ1B = B1' * qo_observability_gramian(A1, B1, M1) * B1,
+    X = sylvc(A1, A2', -B1 * B2'),
 )
-    return sqrt(h2error_sqr(A1, B1, M1, A2, B2, M2; BQ1B, X))
+    return sqrt(abs(h2error_sqr(A1, B1, M1, A2, B2, M2; BQ1B, X)))
 end
 
 """
@@ -67,10 +69,9 @@ end
     h2error_sqr_fast(A1, B1, M1, A2, B2, M2)
 
 Computes the **square** of the h2-error between two quadratic output systems
-defined by `A1`, `B1`, and `M1` and `A2`, `B2`, and `M2`, respectively.
-Note that the optional named argumentd `BQ1B`, which defaults to
-`B1'*qo_observability_gramian(A1, B1, M1)*B1` can be passed, if `BQ1B` is known
-beforehand.
+defined by `A1`, `B1`, and `M1` and `A2`, `B2`, and `M2`, respectively. This is
+faster, if only `M2` is changed and size(A1, 1) << size(A2, 1) because all
+larger Sylvester and Lyapunov equations are solved beforehand.
 """
 function h2error_sqr_fast(
     A1,
@@ -92,9 +93,9 @@ end
 function sylvester_helper(A1, A2, B1, B2, M1, X)
     n = size(A1, 1)
     r = size(A2, 1)
-    AS = kron(I(r), A1) + (kron(A2', I(n)))
+    AS = kron(I(r), A1') + (kron(A2', I(n)))
     J2h = AS\(kron(I(r), M1 * X))
-    J2 = -0.5*(kron(B2', B1'))*J2h
+    J2 = -2*(kron(B2', B1'))*J2h
     return J2
 end
 
@@ -105,11 +106,9 @@ Computes the quadratic-output observability gramian as defined in BenPD2022 for 
 """
 function qo_observability_gramian(A, B, M)
     @assert M == M' "Please provide a symmetric M. Note that this can be assumed for QO-systems without loss of generality"
-    P = controllability_gramian(A, B)
-    MPM = M * P * M
-    MPM = 0.5 * (MPM + MPM')
-    Q = lyapc(Array(A'), M * P * M)
-    return 0.5 * (Q + Q')
+    PU = controllability_gramian_factor(A, B)
+    U = plyapc(Array(A'), M*PU)
+    return U*U'
 end
 
 """
@@ -121,6 +120,11 @@ Note that we use the function `plyapc` to ensure a positive (semi) definite solu
 function controllability_gramian(A, B)
     P = plyapc(A, B)
     return P * P'
+end
+
+function controllability_gramian_factor(A, B)
+    U = plyapc(A, B)
+    return U
 end
 
 export qo_observability_gramian, h2norm, h2error, h2error_sqr

--- a/src/QuadraticOutputSystems.jl
+++ b/src/QuadraticOutputSystems.jl
@@ -64,6 +64,41 @@ function h2error_sqr(
 end
 
 """
+    h2error_sqr_fast(A1, B1, M1, A2, B2, M2)
+
+Computes the **square** of the h2-error between two quadratic output systems
+defined by `A1`, `B1`, and `M1` and `A2`, `B2`, and `M2`, respectively.
+Note that the optional named argumentd `BQ1B`, which defaults to
+`B1'*qo_observability_gramian(A1, B1, M1)*B1` can be passed, if `BQ1B` is known
+beforehand.
+"""
+function h2error_sqr_fast(
+    A1,
+    B1,
+    M1,
+    A2,
+    B2,
+    M2;
+    BQ1B = B1' * qo_observability_gramian(A1, B1, M1) * B1,
+    X = sylvc(A1, A2', -B1 * B2'),
+    J2 = sylvester_helper(A1, A2, B1, B2, M1, X),
+)
+    m = size(B1, 2)
+    TwiceB1TZB = reshape(J2 * vec(M2), m, m)
+    Q2 = qo_observability_gramian(A2, B2, M2)
+    return tr(BQ1B + B2' * Q2 * B2 - TwiceB1TZB)
+end
+
+function sylvester_helper(A1, A2, B1, B2, M1, X)
+    n = size(A1, 1)
+    r = size(A2, 1)
+    AS = kron(I(r), A1) + (kron(A2', I(n)))
+    J2h = AS\(kron(I(r), M1 * X))
+    J2 = -0.5*(kron(B2', B1'))*J2h
+    return J2
+end
+
+"""
     qo_observability_gramian(A, B, M)
 
 Computes the quadratic-output observability gramian as defined in BenPD2022 for a quadratic output system with system matrices ``A, B, M``.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,4 +55,16 @@ end
         β = h2error(A1, B1, M1, A1, B1, M1)
         @test β < 1e-6
     end
+
+    @testset "QH2-error-fast" begin
+        rng = MersenneTwister(0)
+        A1, B1, M1 = generate_stable_qo_system!(rng, 10, 1)
+        A2, B2, M2 = generate_stable_qo_system!(rng, 15, 1)
+        β1 = h2error_sqr(A1, B1, M1, A2, B2, M2)
+        β2 = QuadraticOutputSystems.h2error_sqr_fast(A1, B1, M1, A2, B2, M2)
+        @test_broken β1 ≈ β2
+        # This should be zero.
+        β = QuadraticOutputSystems.h2error_sqr_fast(A1, B1, M1, A1, B1, M1)
+        @test_broken β < 1e-6
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,8 @@ end
         A, B, M = generate_stable_qo_system!(MersenneTwister(0), 10, 2)
         Q = qo_observability_gramian(A, B, M)
         @test is_positive_definite(Q)
-        # TODO: Check that Q is in fact the QO-gramian.
+        P = QuadraticOutputSystems.controllability_gramian(A, B)
+        @test norm(A'*Q + Q*A + M*P*M) < 1e-6
     end
 
     @testset "QH2-norm" begin
@@ -48,23 +49,22 @@ end
 
     @testset "QH2-error" begin
         rng = MersenneTwister(0)
-        A1, B1, M1 = generate_stable_qo_system!(rng, 10, 2)
+        A1, B1, M1 = generate_stable_qo_system!(rng, 25, 2)
         A2, B2, M2 = generate_stable_qo_system!(rng, 15, 2)
         β = h2error(A1, B1, M1, A2, B2, M2)
         @test β >= 0
         β = h2error(A1, B1, M1, A1, B1, M1)
-        @test β < 1e-6
+        @test β < 1e-5
     end
 
     @testset "QH2-error-fast" begin
         rng = MersenneTwister(0)
-        A1, B1, M1 = generate_stable_qo_system!(rng, 10, 1)
-        A2, B2, M2 = generate_stable_qo_system!(rng, 15, 1)
+        A1, B1, M1 = generate_stable_qo_system!(rng, 20, 2)
+        A2, B2, M2 = generate_stable_qo_system!(rng, 15, 2)
         β1 = h2error_sqr(A1, B1, M1, A2, B2, M2)
         β2 = QuadraticOutputSystems.h2error_sqr_fast(A1, B1, M1, A2, B2, M2)
-        @test_broken β1 ≈ β2
-        # This should be zero.
+        @test β1 ≈ β2
         β = QuadraticOutputSystems.h2error_sqr_fast(A1, B1, M1, A1, B1, M1)
-        @test_broken β < 1e-6
+        @test β < 1e-5
     end
 end


### PR DESCRIPTION
Add h2error computation method that allows to precompute most variables and is faster when only `M2` changes and `size(A1 ,1) >> size(A2, 1)`